### PR TITLE
Bug fix with using a default placeholder image

### DIFF
--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -29,6 +29,12 @@ const ItemPreview = (props) => {
     }
   };
 
+   function validateImage(img){
+    if(!img || img === undefined || img === ""){
+      return "placeholder.png"
+    }
+  }
+
   return (
     <div
       className="card bg-dark border-light p-3"
@@ -37,7 +43,9 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={
+          validateImage(item.image)
+        }
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />


### PR DESCRIPTION
we used the placeholder.png default place holder whenever the item.image property is empty, undefined of null
